### PR TITLE
chore: Bumps source commit and go version

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/ausf.git
     source-type: git
-    source-commit: c84dff44b1553bee9c94e153e42ca00b5c1d016b
+    source-commit: 874846b42eda132df42fa66fb2497d77f2c564d2
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

As we bumped to go version to 1.21 in the upstream project and made many dependency updates there, we bump the commit to the latest one available in the upstream project that contains all those changes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
