### PR TITLE
chore: Update CI triggers to not duplicate CI runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,14 @@ name: Main
 
 on:
   pull_request:
+    types: [edited, opened, reopened, synchronize]
     branches:
       - main
+      - v**
   push:
+    branches:
+      - main
+      - v**
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
# Description

Triggers CI only for pull requests or push, not both at the same time. This will prevent duplicate CI jobs and prevent CI failures triggered by push on PRs.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
