### PR TITLE
chore: bump workload to v1.6.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@
 ```bash
 sudo snap install rockcraft --classic --edge
 rockcraft pack -v
-sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-ausf_1.4.1_amd64.rock docker-daemon:sdcore-ausf:1.4.1
-docker run sdcore-ausf:1.4.1
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-ausf_1.6.2_amd64.rock docker-daemon:sdcore-ausf:1.6.2
+docker run sdcore-ausf:1.6.2
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for SD-Core AUSF.
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-ausf:1.6.0
-docker run -it ghcr.io/canonical/sdcore-ausf:1.6.0
+docker pull ghcr.io/canonical/sdcore-ausf:1.6.2
+docker run -it ghcr.io/canonical/sdcore-ausf:1.6.2
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-ausf
 base: bare
 build-base: ubuntu@24.04
-version: '1.6.0'
+version: '1.6.2'
 summary: SD-Core AUSF
 description: SD-Core AUSF
 license: Apache-2.0
@@ -16,7 +16,7 @@ parts:
     source-type: git
     source-tag: v${CRAFT_PROJECT_VERSION}
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     stage-packages:
       - libc6_libs
       - base-files_lib


### PR DESCRIPTION
# Description

Bump AUSF workload to the latest upstream release v1.6.2. We also bump the go version to the same as used in the upstream project: 1.23.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
